### PR TITLE
Update references to github.com/casualjim

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	swaggererrors "github.com/casualjim/go-swagger/errors"
-	"github.com/casualjim/go-swagger/spec"
-	"github.com/casualjim/go-swagger/strfmt"
-	"github.com/casualjim/go-swagger/validate"
+	swaggererrors "github.com/go-swagger/go-swagger/errors"
+	"github.com/go-swagger/go-swagger/spec"
+	"github.com/go-swagger/go-swagger/strfmt"
+	"github.com/go-swagger/go-swagger/validate"
 )
 
 type Schema struct {


### PR DESCRIPTION
The github.com/casualjim/go-swagger project has moved to github.com/go-swagger/go-swagger